### PR TITLE
Fix redirect for /r/* path spec

### DIFF
--- a/lib/Reddit/PP/Web/Controller/Subreddit.pm
+++ b/lib/Reddit/PP/Web/Controller/Subreddit.pm
@@ -21,7 +21,7 @@ sub base : CaptureArgs(1) : PathPart('r') : Chained('/root/base') {
 sub base_index : Args(0) : PathPart('') : Chained('base') {
     my( $self, $ctx ) = @_;
     push @{ $ctx->stash->{reddit_port} }, '::Subbredit->base_index';
-    return $ctx->response->redirect($ctx->uri_for('/subreddits/base_index'));
+    return $ctx->response->redirect($ctx->uri_for_action('/subreddit/base_index'));
 }
 
 __PACKAGE__->meta->make_immutable;


### PR DESCRIPTION
I came across your you repo via your related [2014 Catalyst Advent Calendar article](http://www.catalystframework.org/calendar/2014/15).  I have been studying your example in order to to better understand how chained controllers work.

In playing with the code, I noticed that the request path spec of `/r/*` was not redirecting to a valid address.  I fixed what appears to be a typo and replaced the `uri_for` method with `uri_for_action`.
